### PR TITLE
Add specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require 'spec-helper'

--- a/lib/sendgrid-actionmailer.rb
+++ b/lib/sendgrid-actionmailer.rb
@@ -19,8 +19,8 @@ module SendGridActionMailer
     def deliver!(mail)
       email = SendGrid::Mail.new do |m|
         m.to      = mail[:to].addresses
-        m.from    = mail[:from]
-        m.subject = mail[:subject]
+        m.from    = mail[:from].value
+        m.subject = mail.subject
       end
 
       # TODO: This is pretty ugly
@@ -53,8 +53,8 @@ module SendGridActionMailer
           t.write(a.read)
           email.add_attachment(t, a.filename)
         end
-
       end
+
       @client.send(email)
     end
 

--- a/lib/sendgrid-actionmailer.rb
+++ b/lib/sendgrid-actionmailer.rb
@@ -7,6 +7,8 @@ require 'sendgrid-ruby'
 
 module SendGridActionMailer
   class DeliveryMethod
+    attr_reader :client
+
     def initialize(params)
       @client = SendGrid::Client.new do |c|
         c.api_user = params[:api_user]

--- a/lib/sendgrid-actionmailer.rb
+++ b/lib/sendgrid-actionmailer.rb
@@ -31,32 +31,26 @@ module SendGridActionMailer
       when 'text/html'
         # HTML
         email.html = mail.body.decoded
-      when 'multipart/alternative'
-        # Text and HTML
-        email.text = mail.text_part.decoded
-        email.html = mail.html_part.decoded
-      when 'multipart/mixed'
-        # Text and/or HTML and Attachment
-        if mail.text_part.nil?
-          email.html = mail.html_part.decoded
-        elsif mail.html_part.nil?
-          email.text = mail.text_part.decoded
-        else
-          email.text = mail.text_part.decoded
-          email.html = mail.html_part.decoded
-        end
+      when 'multipart/alternative', 'multipart/mixed'
+        email.html = mail.html_part.decoded if mail.html_part
+        email.text = mail.text_part.decoded if mail.text_part
 
         # This needs to be done better
         mail.attachments.each do |a|
-          t = Tempfile.new("sendgrid-actionmailer#{rand(1000)}")
-          t.binmode
-          t.write(a.read)
-          email.add_attachment(t, a.filename)
+          begin
+            t = Tempfile.new("sendgrid-actionmailer")
+            t.binmode
+            t.write(a.read)
+            t.flush
+            email.add_attachment(t, a.filename)
+          ensure
+            t.close
+            t.unlink
+          end
         end
       end
 
-      @client.send(email)
+      client.send(email)
     end
-
   end
 end

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '~>3.2.0'
 end

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sendgrid-ruby', '~> 0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'mail', '~>2.6.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~>3.2.0'
 end

--- a/spec/lib/sendgrid-actionmailer-spec.rb
+++ b/spec/lib/sendgrid-actionmailer-spec.rb
@@ -35,7 +35,7 @@ module SendGridActionMailer
         )
       end
 
-      before { SendGrid::Client.stub(:new).and_return(client) }
+      before { allow(SendGrid::Client).to receive(:new).and_return(client) }
 
       it 'sets to' do
         mailer.deliver!(mail)
@@ -50,6 +50,82 @@ module SendGridActionMailer
       it 'sets subject' do
         mailer.deliver!(mail)
         expect(client.sent_mail.subject).to eq('Hello, world!')
+      end
+
+      it 'sets a text/plain body' do
+        mail.content_type = 'text/plain'
+        mail.body = 'I heard you like pineapple.'
+        mailer.deliver!(mail)
+        expect(client.sent_mail.text).to eq('I heard you like pineapple.')
+      end
+
+      it 'sets a text/html body' do
+        mail.content_type = 'text/html'
+        mail.body = 'I heard you like <b>pineapple</b>.'
+        mailer.deliver!(mail)
+        expect(client.sent_mail.html).to eq('I heard you like <b>pineapple</b>.')
+      end
+
+      context 'multipart/alternative' do
+        before do
+          mail.content_type 'multipart/alternative'
+          mail.part do |part|
+            part.text_part = Mail::Part.new do
+              content_type 'text/plain'
+              body 'I heard you like pineapple.'
+            end
+            part.html_part = Mail::Part.new do
+              content_type 'text/html'
+              body 'I heard you like <b>pineapple</b>.'
+            end
+          end
+        end
+
+        it 'sets the text body' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.text).to eq('I heard you like pineapple.')
+        end
+
+        it 'sets the html body' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.html)
+            .to eq('I heard you like <b>pineapple</b>.')
+        end
+      end
+
+      context 'multipart/mixed' do
+        before do
+          mail.content_type 'multipart/mixed'
+          mail.part do |part|
+            part.text_part = Mail::Part.new do
+              content_type 'text/plain'
+              body 'I heard you like pineapple.'
+            end
+            part.html_part = Mail::Part.new do
+              content_type 'text/html'
+              body 'I heard you like <b>pineapple</b>.'
+            end
+          end
+          mail.attachments['specs.rb'] = File.read(__FILE__)
+        end
+
+        it 'sets the text body' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.text).to eq('I heard you like pineapple.')
+        end
+
+        it 'sets the html body' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.html)
+            .to eq('I heard you like <b>pineapple</b>.')
+        end
+
+        it 'adds the attachment' do
+          mailer.deliver!(mail)
+          attachment = client.sent_mail.attachments.first
+          expect(attachment[:name]).to eq('specs.rb')
+          expect(attachment[:file].read).to eq(File.read(__FILE__))
+        end
       end
     end
   end

--- a/spec/lib/sendgrid-actionmailer-spec.rb
+++ b/spec/lib/sendgrid-actionmailer-spec.rb
@@ -1,0 +1,19 @@
+require 'sendgrid-actionmailer'
+
+module SendGridActionMailer
+  describe DeliveryMethod do
+    describe '#initialize' do
+      subject(:delivery) do
+        DeliveryMethod.new(api_user: 'user', api_key: 'key')
+      end
+
+      it 'configures the client API user' do
+        expect(delivery.client.api_user).to eq('user')
+      end
+
+      it 'configures the client API key' do
+        expect(delivery.client.api_key).to eq('key')
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid-actionmailer-spec.rb
+++ b/spec/lib/sendgrid-actionmailer-spec.rb
@@ -1,18 +1,55 @@
+require 'mail'
 require 'sendgrid-actionmailer'
 
 module SendGridActionMailer
   describe DeliveryMethod do
-    describe '#initialize' do
-      subject(:delivery) do
-        DeliveryMethod.new(api_user: 'user', api_key: 'key')
-      end
+    subject(:mailer) do
+      DeliveryMethod.new(api_user: 'user', api_key: 'key')
+    end
 
+    class TestClient
+      attr_reader :sent_mail
+
+      def send(mail)
+        @sent_mail = mail
+      end
+    end
+
+    describe '#initialize' do
       it 'configures the client API user' do
-        expect(delivery.client.api_user).to eq('user')
+        expect(mailer.client.api_user).to eq('user')
       end
 
       it 'configures the client API key' do
-        expect(delivery.client.api_key).to eq('key')
+        expect(mailer.client.api_key).to eq('key')
+      end
+    end
+
+    describe '#deliver!' do
+      let(:client) { TestClient.new }
+      let(:mail) do
+        Mail.new(
+          to:      'test@sendgrid.com',
+          from:    'taco@cat.limo',
+          subject: 'Hello, world!'
+        )
+      end
+
+      before { SendGrid::Client.stub(:new).and_return(client) }
+
+      it 'sets to' do
+        mailer.deliver!(mail)
+        expect(client.sent_mail.to).to eq(%w[test@sendgrid.com])
+      end
+
+      it 'sets from' do
+        mailer.deliver!(mail)
+        expect(client.sent_mail.from).to eq('taco@cat.limo')
+      end
+
+      it 'sets subject' do
+        mailer.deliver!(mail)
+        expect(client.sent_mail.subject).to eq('Hello, world!')
       end
     end
   end

--- a/spec/spec-helper.rb
+++ b/spec/spec-helper.rb
@@ -1,0 +1,14 @@
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+
+RSpec.configure do |config|
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # This gem uses dashed filenames, so let's keep the specs consistent.
+  config.pattern = 'spec/**/*-spec.rb'
+end


### PR DESCRIPTION
I need to make some additions to use this gem (at least in our fork of it), but obviously don't want to break anything. This adds RSpec as a development dependency and tests the current functionality. While speccing, I found a couple issues and simplified the body parsing somewhat.

- `rspec` added for testing
- `mail` added to build mail in specs
- Test `SendGridActionMailer::DeliveryMethod#new` and `#deliver!`
- Fix `mail.from` not being a `String`
- Simplify body parsing in the `/mixed` and `/alternative` cases
- Safer attachment file handling

Something that made this a little difficult is the use of dashes in filenames - Guard and a variety of other tools expects Ruby projects to use underscores thanks to Rails using that convention. I didn't want to go around renaming things and breaking any `require`s people already have using dashes, but it's something to consider.