### PR TITLE
Add CC and BCC fields

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -19,6 +19,8 @@ module SendGridActionMailer
     def deliver!(mail)
       email = SendGrid::Mail.new do |m|
         m.to      = mail[:to].addresses
+        m.cc      = mail[:cc].addresses  if mail[:cc]
+        m.bcc     = mail[:bcc].addresses if mail[:bcc]
         m.from    = mail[:from].value
         m.subject = mail.subject
       end

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -46,6 +46,24 @@ module SendGridActionMailer
         expect(client.sent_mail.from).to eq('taco@cat.limo')
       end
 
+      context 'there are ccs' do
+        before { mail.cc = 'burrito@cat.limo' }
+
+        it 'sets cc' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.cc).to eq(%w[burrito@cat.limo])
+        end
+      end
+
+      context 'there are bccs' do
+        before { mail.bcc = 'nachos@cat.limo' }
+
+        it 'sets bcc' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.bcc).to eq(%w[nachos@cat.limo])
+        end
+      end
+
       it 'sets subject' do
         mailer.deliver!(mail)
         expect(client.sent_mail.subject).to eq('Hello, world!')


### PR DESCRIPTION
Add support for CC and BCCs. Since those fields are `nil` if not specified, I
declare them in a `context` so the main spec scope runs that path.