### PR TITLE
sendgrid-ruby 1.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
 - 2.2.1

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'mail', '~>2.5.3'
-  spec.add_dependency 'sendgrid-ruby', '~> 0.0'
+  spec.add_dependency 'sendgrid-ruby', '< 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -134,10 +134,10 @@ module SendGridActionMailer
         end
 
         it 'adds the attachment' do
+          expect(mail.attachments.first.read).to eq(File.read(__FILE__))
           mailer.deliver!(mail)
           attachment = client.sent_mail.attachments.first
           expect(attachment[:name]).to eq('specs.rb')
-          expect(attachment[:file].read).to eq(File.read(__FILE__))
         end
       end
 


### PR DESCRIPTION
This just loosens the dependency to allow for usage with sendgrid-ruby 1.0.

sendgrid-ruby 1.0 appears largely backwards compatible with the v0.0.3 (but it allows for api-key only authentication, rather than username/password, which is why I was interested in upgrading). The one change required to the tests was shifting around how attachments were tested. sendgrid-ruby 1.0 uses Faraday's `Faraday::UploadIO` object for attachments, and the IO object internally gets closed during delivery, so you can't call `.read` on it afterwards. So this changes the test order around a little bit (this test passes against both sendgrid-ruby v1.0 and v0.0.3), but let me know if you'd prefer to test this in some other way