### PR TITLE
Fix default require for dasherized gem name

### DIFF
--- a/lib/sendgrid-actionmailer.rb
+++ b/lib/sendgrid-actionmailer.rb
@@ -1,0 +1,1 @@
+require "sendgrid_actionmailer"


### PR DESCRIPTION
Since the gem's name is "sendgrid-actionmailer", if you're relying on Bundler auto-requiring the gem based on the name (as is default in Rails), this won't work since the internal rename using underscores in 086de8510f668c0d03eef414513c64bee7a35f19. This just adds an file to provide an alias so requiring the dasherized name still works.