### PR TITLE
Implement missing X-SMTPAPI support

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -32,8 +32,41 @@ module SendGridActionMailer
       if smtpapi && smtpapi.value
         begin
           data = JSON.parse(smtpapi.value)
-          Array(data['category']).each do |category|
-            email.smtpapi.add_category(category)
+
+          if data['filters']
+            email.smtpapi.set_filters(data['filters'])
+          end
+
+          if data['category']
+            email.smtpapi.set_categories(data['category'])
+          end
+
+          if data['send_at']
+            email.smtpapi.set_send_at(data['send_at'])
+          end
+
+          if data['send_each_at']
+            email.smtpapi.set_send_each_at(data['send_each_at'])
+          end
+
+          if data['section']
+            email.smtpapi.set_sections(data['section'])
+          end
+
+          if data['sub']
+            email.smtpapi.set_substitutions(data['sub'])
+          end
+
+          if data['asm_group_id']
+            email.smtpapi.set_asm_group(data['asm_group_id'])
+          end
+
+          if data['unique_args']
+            email.smtpapi.set_unique_args(data['unique_args'])
+          end
+
+          if data['ip_pool']
+            email.smtpapi.set_ip_pool(data['ip_pool'])
           end
         rescue JSON::ParserError
           raise ArgumentError, "X-SMTPAPI is not JSON: #{smtpapi.value}"

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -171,6 +171,43 @@ module SendGridActionMailer
           end
         end
 
+        context 'filters are present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              filters: {
+                clicktrack: {
+                  settings: {
+                    enable: 0
+                  }
+                },
+                dkim: {
+                  settings: {
+                    domain: 'example.com',
+                    use_from: false
+                  }
+                }
+              }
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.filters).to eq({
+              'clicktrack' => {
+                'settings' => {
+                  'enable' => 0
+                }
+              },
+              'dkim' => {
+                'settings' => {
+                  'domain' => 'example.com',
+                  'use_from' => false
+                }
+              }
+            })
+          end
+        end
+
         context 'a category is present' do
           before do
             mail['X-SMTPAPI'] = { category: 'food_feline' }.to_json
@@ -178,7 +215,7 @@ module SendGridActionMailer
 
           it 'gets attached' do
             mailer.deliver!(mail)
-            expect(client.sent_mail.smtpapi.category).to include('food_feline')
+            expect(client.sent_mail.smtpapi.category).to eq('food_feline')
           end
         end
 
@@ -191,8 +228,131 @@ module SendGridActionMailer
 
           it 'attaches them all' do
             mailer.deliver!(mail)
-            expect(client.sent_mail.smtpapi.category)
-              .to include('food_feline', 'cuisine_canine')
+            expect(client.sent_mail.smtpapi.category).to eq([
+              'food_feline',
+              'cuisine_canine',
+            ])
+          end
+        end
+
+        context 'send_at is present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              send_at: 1409348513
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.send_at).to eq(1409348513)
+          end
+        end
+
+        context 'send_each_at is present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              send_each_at: [1409348513, 1409348514]
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.send_each_at).to eq([1409348513, 1409348514])
+          end
+        end
+
+        context 'section is present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              section: {
+                ":sectionName1" => "section 1 text",
+                ":sectionName2" => "section 2 text"
+              }
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.section).to eq({
+              ":sectionName1" => "section 1 text",
+              ":sectionName2" => "section 2 text"
+            })
+          end
+        end
+
+        context 'sub is present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              sub: {
+                "-name-" => [
+                  "John",
+                  "Jane"
+                ],
+                "-customerID-" => [
+                  "1234",
+                  "5678"
+                ],
+              }
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.sub).to eq({
+              "-name-" => [
+                "John",
+                "Jane"
+              ],
+              "-customerID-" => [
+                "1234",
+                "5678"
+              ],
+            })
+          end
+        end
+
+        context 'asm_group_id is present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              asm_group_id: 1
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.asm_group_id).to eq(1)
+          end
+        end
+
+        context 'unique_args are present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              unique_args: {
+                customerAccountNumber: "55555",
+                activationAttempt: "1",
+              }
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.unique_args).to eq({
+              "customerAccountNumber" => "55555",
+              "activationAttempt" => "1",
+            })
+          end
+        end
+
+        context 'ip_pool is present' do
+          before do
+            mail['X-SMTPAPI'] = {
+              ip_pool: "pool_name"
+            }.to_json
+          end
+
+          it 'gets attached' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.ip_pool).to eq("pool_name")
           end
         end
       end


### PR DESCRIPTION
In addition to the existing category support, this adds support for the remaining X-SMTPAPI options supported by smtpapi-ruby:

- filters
- send_at
- send_each_at
- section
- sub
- asm_group_id
- unique_args
- ip_pool

I think ideally, we'd just pass the `X-SMTPAPI` header through verbatim, so sendgrid-actionmailer wouldn't need to explicitly support any individual options (because it also feels a little overkill to be serializing, deserializing, and then re-sereializing this JSON). However, the current versions of sendgrid-ruby and smtpapi-ruby don't seem to support this. It sounds like there's a rework of those libraries possibly [in progress](https://github.com/sendgrid/sendgrid-ruby/pull/51#issuecomment-200041207), so rather than trying to address that kind of usage upstream, we'll just work with the current library APIs and be a little repetitive. But I think this should cover all the options smtpapi-ruby supports.