### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SendGrid ActionMailer
 
-SendGrid support for Rails via ActionMailer.
+An ActionMailer adapter to send email using SendGrid's HTTPS Web API (instead of SMTP).
 
 [![BuildStatus](https://travis-ci.org/eddiezane/sendgrid-actionmailer.svg?branch=master)](https://travis-ci.org/eddiezane/sendgrid-actionmailer)
 
@@ -21,12 +21,74 @@ Or install it yourself as:
 
 ## Usage
 
-Edit your `config/environments/$ENVIRONMENT.rb` file and add/change the following to the ActionMailer configuration.
+Create a [SendGrid API Key](https://app.sendgrid.com/settings/api_keys) for your application. Then edit `config/application.rb` or `config/environments/$ENVIRONMENT.rb` and add/change the following to the ActionMailer configuration:
 
-	  config.action_mailer.delivery_method = :sendgrid_actionmailer
-	  config.action_mailer.sendgrid_actionmailer_settings = {api_user: ENV['SENDGRID_USERNAME'], api_key: ENV['SENDGRID_PASSWORD']}
+```ruby
+config.action_mailer.delivery_method = :sendgrid_actionmailer
+config.action_mailer.sendgrid_actionmailer_settings = {
+  api_key: ENV['SENDGRID_API_KEY']
+}
+```
 
-TODO: Add ActionMailer instructions.
+Normal ActionMailer usage will now transparently be sent using SendGrid's Web API.
+
+### X-SMTPAPI
+
+You may optionally set SendGrid's [X-SMTPAPI](https://sendgrid.com/docs/API_Reference/SMTP_API/index.html) header on messages to control SendGrid specific functionality. This header must be set to a JSON string.
+
+```ruby
+class UserMailer < ApplicationMailer
+  def welcome_email(user)
+    headers['X-SMTPAPI'] = {
+      category: ['newuser']
+    }.to_json
+
+    mail(to: user.email, subject: 'Welcome to My Awesome Site')
+  end
+end
+```
+
+The following `X-SMTPAPI` options are supported:
+
+- `filters`
+- `category`
+- `send_at`
+- `send_each_at`
+- `section`
+- `sub`
+- `asm_group_id`
+- `unique_args`
+- `ip_pool`
+
+#### X-SMTPAPI Defaults
+
+Default values for the `X-SMTPAPI` header may be set at different levels using ActionMailer's normal options for setting default headers. However, since `X-SMTPAPI` is treated as a single string value, it's important to note that default values at different levels will not get merged together. So if you override the `X-SMTPAPI` header at any level, you may need to repeat any default values at more specific levels.
+
+Global defaults can be set inside `config/application.rb`:
+
+```ruby
+config.action_mailer.default_options = {
+  'X-SMTPAPI' => {
+    ip_pool: 'marketing_ip_pool'
+  }.to_json
+}
+```
+
+Per-mailer defaults can be set inside an ActionMailer class:
+
+```ruby
+class NewsletterMailer < ApplicationMailer
+  default('X-SMTPAPI' => {
+    category: ['newsletter'],
+
+    # Assuming the above "config.action_mailer.default_options" global default
+    # example, the default "ip_pool" value must be repeated here if you want
+    # that default value to also apply to this specific mailer that's
+    # specifying it's own default X-SMTPAPI value.
+    ip_pool: 'marketing_ip_pool'
+  }.to_json)
+end
+```
 
 ## Contributing
 


### PR DESCRIPTION
Clarify a few things in the README, use API keys as the default authentication example (as sendgrid-ruby does now), and provide more details on X-SMTPAPI usage.