### PR TITLE
Attachment fixes

### DIFF
--- a/gemfiles/mail_2.5.gemfile.lock
+++ b/gemfiles/mail_2.5.gemfile.lock
@@ -8,13 +8,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.0)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -36,6 +40,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    safe_yaml (1.0.4)
     sendgrid-ruby (1.1.6)
       faraday (~> 0.9)
       mimemagic
@@ -45,6 +50,10 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -56,6 +65,7 @@ DEPENDENCIES
   rake
   rspec (~> 3.2.0)
   sendgrid-actionmailer!
+  webmock (~> 1.24.6)
 
 BUNDLED WITH
    1.11.2

--- a/gemfiles/mail_2.6.gemfile.lock
+++ b/gemfiles/mail_2.6.gemfile.lock
@@ -8,13 +8,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.0)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     mime-types (2.99.1)
@@ -34,12 +38,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    safe_yaml (1.0.4)
     sendgrid-ruby (1.1.6)
       faraday (~> 0.9)
       mimemagic
       smtpapi (~> 0.1)
     smtpapi (0.1.0)
     thor (0.19.1)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -51,6 +60,7 @@ DEPENDENCIES
   rake
   rspec (~> 3.2.0)
   sendgrid-actionmailer!
+  webmock (~> 1.24.6)
 
 BUNDLED WITH
    1.11.2

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -88,7 +88,9 @@ module SendGridActionMailer
 
         # This needs to be done better
         mail.attachments.each do |a|
-          t = Tempfile.new("sendgrid-actionmailer")
+          # Create a tempfile with the same file extension as the real file
+          # for sendgrid-ruby's mime type lookups.
+          t = Tempfile.new(["sendgrid-actionmailer", File.extname(a.filename)])
           t.binmode
           t.write(a.read)
           t.flush

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -17,6 +17,7 @@ module SendGridActionMailer
     end
 
     def deliver!(mail)
+      attachment_tempfiles = []
       from = mail[:from].addrs.first
 
       email = SendGrid::Mail.new do |m|
@@ -87,20 +88,24 @@ module SendGridActionMailer
 
         # This needs to be done better
         mail.attachments.each do |a|
-          begin
-            t = Tempfile.new("sendgrid-actionmailer")
-            t.binmode
-            t.write(a.read)
-            t.flush
-            email.add_attachment(t, a.filename)
-          ensure
-            t.close
-            t.unlink
-          end
+          t = Tempfile.new("sendgrid-actionmailer")
+          t.binmode
+          t.write(a.read)
+          t.flush
+          t.rewind
+          email.add_attachment(t, a.filename)
+          attachment_tempfiles << t
         end
       end
 
       client.send(email)
+    ensure
+      # Close and delete the attachment tempfiles after the e-mail has been
+      # sent.
+      attachment_tempfiles.each do |file|
+        file.close
+        file.unlink
+      end
     end
   end
 end

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~>3.2.0'
   spec.add_development_dependency 'appraisal', '~> 2.1.0'
+  spec.add_development_dependency 'webmock', '~> 1.24.6'
 end

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -162,6 +162,7 @@ module SendGridActionMailer
           mailer.deliver!(mail)
           attachment = client.sent_mail.attachments.first
           expect(attachment[:name]).to eq('specs.rb')
+          expect(attachment[:file].content_type.to_s).to eq('application/x-ruby')
         end
       end
 

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -1,4 +1,5 @@
 require 'mail'
+require 'webmock/rspec'
 
 module SendGridActionMailer
   describe DeliveryMethod do
@@ -6,11 +7,12 @@ module SendGridActionMailer
       DeliveryMethod.new(api_user: 'user', api_key: 'key')
     end
 
-    class TestClient
+    class TestClient < SendGrid::Client
       attr_reader :sent_mail
 
       def send(mail)
         @sent_mail = mail
+        super(mail)
       end
     end
 
@@ -34,7 +36,11 @@ module SendGridActionMailer
         )
       end
 
-      before { allow(SendGrid::Client).to receive(:new).and_return(client) }
+      before do
+        stub_request(:any, 'https://api.sendgrid.com/api/mail.send.json')
+          .to_return(body: {message: 'success'}.to_json, status: 200, headers: {'X-TEST' => 'yes'})
+        allow(SendGrid::Client).to receive(:new).and_return(client)
+      end
 
       it 'sets to' do
         mailer.deliver!(mail)


### PR DESCRIPTION
This fixes two things with attachments being sent:

- Fix attachment tempfiles being closed and deleted before they're used.

  This was leading to IOError: closed stream errors when used with sendgrid-ruby v1.

  This changes the tests so this error would have been thrown by still performing all of the default SendGrid::Client behavior, and only mocking the HTTP request (in the same way sendgrid-ruby mocks things). This allows for sendgrid-ruby's internal attachment handling to still run, which is where this error cropped up with the closed files we were sending in.
- Fix content-type lookups on attachments.

  sendgrid-ruby's mime type lookup logic is based on the tempfile's path,
but since the tempfiles didn't have a file extension, it was always nil.
This fixes things by ensuring the tempfile has the same file extension
as the original filename.