### PR TITLE
Add missing support for `reply_to` and `date` options

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -26,6 +26,8 @@ module SendGridActionMailer
         m.bcc       = mail[:bcc].addresses if mail[:bcc]
         m.from      = from.address
         m.from_name = from.display_name
+        m.reply_to  = mail[:reply_to].addresses.first if mail[:reply_to]
+        m.date      = mail[:date].to_s if mail[:date]
         m.subject   = mail.subject
       end
 

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -65,6 +65,33 @@ module SendGridActionMailer
         end
       end
 
+      context 'there is a reply to' do
+        before { mail.reply_to = 'nachos@cat.limo' }
+
+        it 'sets reply_to' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.reply_to).to eq('nachos@cat.limo')
+        end
+      end
+
+      context 'there is a reply to with a friendly name' do
+        before { mail.reply_to = 'Taco Cat <nachos@cat.limo>' }
+
+        it 'sets reply_to' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.reply_to).to eq('nachos@cat.limo')
+        end
+      end
+
+      context 'there is a date' do
+        before { mail.date = Time.utc(2016) }
+
+        it 'sets date' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail.date).to eq("Fri, 01 Jan 2016 00:00:00 +0000")
+        end
+      end
+
       it 'sets from' do
         mailer.deliver!(mail)
         expect(client.sent_mail.from).to eq('taco@cat.limo')


### PR DESCRIPTION
This adds supports for the `reply_to` and `date` options. I think this now covers all the main top-level options that the sendgrid-ruby library and the sendgrid API accepts.