### PR TITLE
Fix error when multiple X-SMTPAPI headers were set

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -32,6 +32,18 @@ module SendGridActionMailer
       end
 
       smtpapi = mail['X-SMTPAPI']
+
+      # If multiple X-SMTPAPI headers are present on the message, then pick the
+      # first one. This may happen when X-SMTPAPI is set with defaults at the
+      # class-level (using defaults()), as well as inside an individual method
+      # (using headers[]=). In this case, we'll defer to the more specific
+      # header set in the individual method, which is the first header
+      # (somewhat counter-intuitively:
+      # https://github.com/rails/rails/issues/15912).
+      if(smtpapi.kind_of?(Array))
+        smtpapi = smtpapi.first
+      end
+
       if smtpapi && smtpapi.value
         begin
           data = JSON.parse(smtpapi.value)

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -389,6 +389,18 @@ module SendGridActionMailer
             expect(client.sent_mail.smtpapi.ip_pool).to eq("pool_name")
           end
         end
+
+        context 'multiple X-SMTPAPI headers are present' do
+          before do
+            mail['X-SMTPAPI'] = { category: 'food_canine' }.to_json
+            mail['X-SMTPAPI'] = { category: 'food_feline' }.to_json
+          end
+
+          it 'uses the last header' do
+            mailer.deliver!(mail)
+            expect(client.sent_mail.smtpapi.category).to eq('food_canine')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
If the X-SMTPAPI header was specified multiple times, then we need to deal with an array of possible headers, rather than just a single value.

This helps fix a usage like this:

```ruby
class SomeMailer < ActionMailer::Base
  default("X-SMTPAPI" => JSON.dump({ "category" => ["foo"] }))

  def welcome
    headers["X-SMTPAPI"] = JSON.dump({ "category" => ["bar"] })
    mail
  end
end
```

so that the `welcome` e-mail get sent with `category=["bar"]` (and not `foo`).

This solution of picking the first header perhaps isn't ideal, but there's some odd behavior around how headers get overridden depending on how exactly they're set in actionmailer classes (see https://github.com/rails/rails/issues/15912). For example, a `mail("X-SMTPAPI" => ...)` call within a specific method wouldn't result multiple headers the same way `headers[]=` does. The primary edge-case where picking the first header might not lead to the expected result is if you were to call `headers["X-SMTPAPI"]=` multiple times within a single method, since in that case, the first header set will be what's used (rather than the last, which seems more intuitive in that case). But in order to fix the way `headers[]=` gets combined with any `default` options, we have to pick the first header. Since that seems like the most common use-case, this seems like the best option we currently have given some of the odd ActionMailer header semantics.