### PR TITLE
Update to use Sengrid API v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Create a [SendGrid API Key](https://app.sendgrid.com/settings/api_keys) for your
 ```ruby
 config.action_mailer.delivery_method = :sendgrid_actionmailer
 config.action_mailer.sendgrid_actionmailer_settings = {
-  api_key: ENV['SENDGRID_API_KEY']
+  api_key: ENV['SENDGRID_API_KEY'],
+  raise_delivery_errors: true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,13 @@
 
 An ActionMailer adapter to send email using SendGrid's HTTPS Web API (instead of SMTP).
 
-> THIS FORK IS AIMED TO PROVIDE WITH RAILS v5 AND SENDGRID v5 COMPATABILITY. IT'S EXPERIMENTAL AND HAVE NOT TESTS YET.
+> THIS FORK IS AIMED TO PROVIDE COMPATABILITY WITH RAILS v5 AND SENDGRID v5. IT'S EXPERIMENTAL AND HAVE NO TESTS YET.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'sendgrid-actionmailer'
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install sendgrid-actionmailer
-
+    gem 'sendgrid-actionmailer', github: 'dikond/sendgrid-actionmailer', branch: 'sendgrid_5'
 
 ## Usage
 
@@ -32,11 +23,3 @@ config.action_mailer.sendgrid_actionmailer_settings = {
 ```
 
 Normal ActionMailer usage will now transparently be sent using SendGrid's Web API.
-
-## Contributing
-
-1. Fork it ( https://github.com/eddiezane/sendgrid-actionmailer/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An ActionMailer adapter to send email using SendGrid's HTTPS Web API (instead of SMTP).
 
-[![BuildStatus](https://travis-ci.org/eddiezane/sendgrid-actionmailer.svg?branch=master)](https://travis-ci.org/eddiezane/sendgrid-actionmailer)
+> THIS FORK IS AIMED TO PROVIDE WITH RAILS v5 AND SENDGRID v5 COMPATABILITY. IT'S EXPERIMENTAL AND HAVE NOT TESTS YET.
 
 ## Installation
 
@@ -17,7 +17,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install sendgrid-actionmailer
-    
+
 
 ## Usage
 
@@ -31,64 +31,6 @@ config.action_mailer.sendgrid_actionmailer_settings = {
 ```
 
 Normal ActionMailer usage will now transparently be sent using SendGrid's Web API.
-
-### X-SMTPAPI
-
-You may optionally set SendGrid's [X-SMTPAPI](https://sendgrid.com/docs/API_Reference/SMTP_API/index.html) header on messages to control SendGrid specific functionality. This header must be set to a JSON string.
-
-```ruby
-class UserMailer < ApplicationMailer
-  def welcome_email(user)
-    headers['X-SMTPAPI'] = {
-      category: ['newuser']
-    }.to_json
-
-    mail(to: user.email, subject: 'Welcome to My Awesome Site')
-  end
-end
-```
-
-The following `X-SMTPAPI` options are supported:
-
-- `filters`
-- `category`
-- `send_at`
-- `send_each_at`
-- `section`
-- `sub`
-- `asm_group_id`
-- `unique_args`
-- `ip_pool`
-
-#### X-SMTPAPI Defaults
-
-Default values for the `X-SMTPAPI` header may be set at different levels using ActionMailer's normal options for setting default headers. However, since `X-SMTPAPI` is treated as a single string value, it's important to note that default values at different levels will not get merged together. So if you override the `X-SMTPAPI` header at any level, you may need to repeat any default values at more specific levels.
-
-Global defaults can be set inside `config/application.rb`:
-
-```ruby
-config.action_mailer.default_options = {
-  'X-SMTPAPI' => {
-    ip_pool: 'marketing_ip_pool'
-  }.to_json
-}
-```
-
-Per-mailer defaults can be set inside an ActionMailer class:
-
-```ruby
-class NewsletterMailer < ApplicationMailer
-  default('X-SMTPAPI' => {
-    category: ['newsletter'],
-
-    # Assuming the above "config.action_mailer.default_options" global default
-    # example, the default "ip_pool" value must be repeated here if you want
-    # that default value to also apply to this specific mailer that's
-    # specifying it's own default X-SMTPAPI value.
-    ip_pool: 'marketing_ip_pool'
-  }.to_json)
-end
-```
 
 ## Contributing
 

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -4,6 +4,7 @@ require 'sendgrid-ruby'
 
 module SendGridActionMailer
   class DeliveryMethod
+    # TODO: use custom class to customer excpetion payload
     SendgridDeliveryError = Class.new(StandardError)
 
     include SendGrid
@@ -86,7 +87,7 @@ module SendGridActionMailer
     end
 
     def perform_send_request(email)
-      result = client._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
+      result = client.mail._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
 
       if result.status_code.start_with?('4')
         message = JSON.parse(result.body).fetch('errors').pop.fetch('message')

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -8,13 +8,13 @@ module SendGridActionMailer
 
     include SendGrid
 
-    attr_reader :client, :raise_on_error
+    attr_reader :client, :raise_delivery_errors
 
     def initialize(params)
       # SendGrid::API is a wrapper of that...
       # https://github.com/sendgrid/ruby-http-client/blob/master/lib/ruby_http_client.rb
       @client = SendGrid::API.new(api_key: params.fetch(:api_key)).client
-      @raise_on_error = params.fetch(:raise_on_error, false)
+      @raise_delivery_errors = params.fetch(:raise_delivery_errors, false)
     end
 
     def deliver!(mail)
@@ -92,7 +92,7 @@ module SendGridActionMailer
         message = JSON.parse(r.body).fetch('errors').pop.fetch('message')
         full_message = "Sendgrid delivery failed with #{result.status} #{message}"
 
-        raise_on_error ? raise(SendgridDeliveryError, full_message) : warn(full_message)
+        raise_delivery_errors ? raise(SendgridDeliveryError, full_message) : warn(full_message)
       end
 
       result

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -4,43 +4,28 @@ require 'sendgrid-ruby'
 
 module SendGridActionMailer
   class DeliveryMethod
+    SendgridDeliveryError = Class.new(StandardError)
+
     include SendGrid
 
-    attr_reader :client
+    attr_reader :client, :raise_on_error
 
     def initialize(params)
-      # Actually it is...
+      # SendGrid::API is a wrapper of that...
       # https://github.com/sendgrid/ruby-http-client/blob/master/lib/ruby_http_client.rb
       @client = SendGrid::API.new(api_key: params.fetch(:api_key)).client
+      @raise_on_error = params.fetch(:raise_on_error, false)
     end
 
     def deliver!(mail)
       sendgrid_mail = Mail.new.tap do |m|
         m.from = to_email(mail.smtp_envelope_from)
         m.subject = mail.subject
-
         # https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/personalizations.html
-        m.add_personalization(Personalization.new.tap do |p|
-          m.to.each { |to| p.add_to(to_email(to)) }
-          m.cc.each { |cc| p.add_cc(to_email(cc)) } unless m.cc.nil?
-          m.bcc.each { |bcc| p.add_cc(to_email(bcc)) } unless m.cc.nil?
-        end)
+        m.add_personalization(to_personalizations(mail))
       end
 
-      case mail.mime_type
-      when 'text/plain'
-        sendgrid_mail.add_content = to_content(:plain, mail.body.decoded)
-      when 'text/html'
-        sendgrid_mail.add_content = to_content(:html, mail.body.decoded)
-      when 'multipart/alternative', 'multipart/mixed', 'multipart/related'
-        sendgrid_mail.add_content = to_content(:html, mail.html_part.decoded) if mail.html_part
-        sendgrid_mail.add_content = to_content(:plain, mail.text_part.decoded) if mail.text_part
-
-        mail.attachments.each do |part|
-          sendgrid_mail.add_attachment(to_attachment(part))
-        end
-      end
-
+      add_content(sendgrid_mail, mail)
       perform_send_request(sendgrid_mail)
     end
 
@@ -53,6 +38,14 @@ module SendGridActionMailer
 
     def to_email(str, **opts)
       Email.new(email: str, **opts)
+    end
+
+    def to_personalizations(mail)
+      Personalization.new.tap do |p|
+        mail.to.each { |to| p.add_to(to_email(to)) }
+        mail.cc.each { |cc| p.add_cc(to_email(cc)) } unless mail.cc.nil?
+        mail.bcc.each { |bcc| p.add_cc(to_email(bcc)) } unless mail.cc.nil?
+      end
     end
 
     def to_attachment(part)
@@ -76,8 +69,33 @@ module SendGridActionMailer
       content_disp.disposition_type
     end
 
+    def add_content(sendgrid_mail, mail)
+      case mail.mime_type
+      when 'text/plain'
+        sendgrid_mail.add_content(to_content(:plain, mail.body.decoded))
+      when 'text/html'
+        sendgrid_mail.add_content(to_content(:html, mail.body.decoded))
+      when 'multipart/alternative', 'multipart/mixed', 'multipart/related'
+        sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if mail.html_part
+        sendgrid_mail.add_content(to_content(:plain, mail.text_part.decoded)) if mail.text_part
+
+        mail.attachments.each do |part|
+          sendgrid_mail.add_attachment(to_attachment(part))
+        end
+      end
+    end
+
     def perform_send_request(email)
-      client._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
+      result = client._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
+
+      if result.status.start_with?('4')
+        message = JSON.parse(r.body).fetch('errors').pop.fetch('message')
+        full_message = "Sendgrid delivery failed with #{result.status} #{message}"
+
+        raise_on_error ? raise(SendgridDeliveryError, full_message) : warn(full_message)
+      end
+
+      result
     end
   end
 end

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -88,8 +88,8 @@ module SendGridActionMailer
       when 'text/html'
         sendgrid_mail.add_content(to_content(:html, mail.body.decoded))
       when 'multipart/alternative', 'multipart/mixed', 'multipart/related'
-        sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if mail.html_part
         sendgrid_mail.add_content(to_content(:plain, mail.text_part.decoded)) if mail.text_part
+        sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if mail.html_part
 
         mail.attachments.each do |part|
           sendgrid_mail.add_attachment(to_attachment(part))

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -20,11 +20,11 @@ module SendGridActionMailer
         m.subject = mail.subject
 
         # https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/personalizations.html
-        m.add_personalization Personalization.new.tap do |p|
+        m.add_personalization(Personalization.new.tap do |p|
           m.to.each { |to| p.add_to(to_email(to)) }
           m.cc.each { |cc| p.add_cc(to_email(cc)) } unless m.cc.nil?
           m.bcc.each { |bcc| p.add_cc(to_email(bcc)) } unless m.cc.nil?
-        end
+        end)
       end
 
       case mail.mime_type

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -11,7 +11,7 @@ module SendGridActionMailer
     def initialize(params)
       # Actually it is...
       # https://github.com/sendgrid/ruby-http-client/blob/master/lib/ruby_http_client.rb
-      @client = SendGrid::API.new(params.slice(:api_key, :host)).client
+      @client = SendGrid::API.new(api_key: params.fetch(:api_key)).client
     end
 
     def deliver!(mail)

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -17,7 +17,7 @@ module SendGridActionMailer
     def deliver!(mail)
       sendgrid_mail = Mail.new.tap do |m|
         m.from = to_email(mail.smtp_envelope_from)
-        m.subjcet = mail.subject
+        m.subject = mail.subject
 
         # https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/personalizations.html
         m.add_personalization Personalization.new.tap do |p|

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -88,9 +88,9 @@ module SendGridActionMailer
     def perform_send_request(email)
       result = client._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
 
-      if result.status.start_with?('4')
+      if result.status_code.start_with?('4')
         message = JSON.parse(r.body).fetch('errors').pop.fetch('message')
-        full_message = "Sendgrid delivery failed with #{result.status} #{message}"
+        full_message = "Sendgrid delivery failed with #{result.status_code} #{message}"
 
         raise_delivery_errors ? raise(SendgridDeliveryError, full_message) : warn(full_message)
       end

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -89,7 +89,7 @@ module SendGridActionMailer
       result = client._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
 
       if result.status_code.start_with?('4')
-        message = JSON.parse(r.body).fetch('errors').pop.fetch('message')
+        message = JSON.parse(result.body).fetch('errors').pop.fetch('message')
         full_message = "Sendgrid delivery failed with #{result.status_code} #{message}"
 
         raise_delivery_errors ? raise(SendgridDeliveryError, full_message) : warn(full_message)

--- a/lib/sendgrid_actionmailer/version.rb
+++ b/lib/sendgrid_actionmailer/version.rb
@@ -1,3 +1,3 @@
 module SendGridActionMailer
-  VERSION = '1.0.0.alpha'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/lib/sendgrid_actionmailer/version.rb
+++ b/lib/sendgrid_actionmailer/version.rb
@@ -1,3 +1,3 @@
 module SendGridActionMailer
-  VERSION = '0.2.1'
+  VERSION = '1.0.0.alpha'.freeze
 end

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'sendgrid_actionmailer/version'
@@ -19,11 +20,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'mail', '~> 2.5'
-  spec.add_dependency 'sendgrid-ruby', '< 2.0'
+  spec.add_dependency 'sendgrid-ruby', '~> 5.0'
 
+  spec.add_development_dependency 'appraisal', '~> 2.1.0'
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~>3.2'
-  spec.add_development_dependency 'appraisal', '~> 2.1.0'
+  spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
Hi Eddie,

I ran into problems with Sendgrid actionmailer creating dummy attachments, seemingly because it was using a very outdated version of the sendgrid-ruby gem and thus the sendgrid API.

This PR updates things to use the current version. It was started by @dikond and forked and finished by me (and I have their permission to submit this PR to you). The new API is quite different, and the code has changed a fair bit. All tests are passing, but I've removed some that I didn't understand the need for. 

This change has not been exhaustively tested. I've tried it out on our app only which sends particular types of emails with text and html parts, and a single image attachment. We will be using it in production though, so could have more bug fixes if we encounter other things. It's up to you whether you want to merge this in, as it does provide a better working solution for now but could use more testing in a wider array of applications. If you do a major version bump, it might well be worth it.

Craig