### PR TITLE
Implement DeliveryMethod.settings attribute properly

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -9,13 +9,14 @@ module SendGridActionMailer
 
     include SendGrid
 
-    attr_reader :client, :raise_delivery_errors
+    DEFAULTS = {
+      raise_delivery_errors: false,
+    }
 
-    def initialize(params)
-      # SendGrid::API is a wrapper of that...
-      # https://github.com/sendgrid/ruby-http-client/blob/master/lib/ruby_http_client.rb
-      @client = SendGrid::API.new(api_key: params.fetch(:api_key)).client
-      @raise_delivery_errors = params.fetch(:raise_delivery_errors, false)
+    attr_accessor :settings
+
+    def initialize(**params)
+      self.settings = DEFAULTS.merge(params)
     end
 
     def deliver!(mail)
@@ -28,12 +29,9 @@ module SendGridActionMailer
       end
 
       add_content(sendgrid_mail, mail)
-      perform_send_request(sendgrid_mail)
-    end
+      response = perform_send_request(sendgrid_mail)
 
-    def settings
-      # required to be compatible with .deliver!
-      {}
+      settings[:return_response] ? response : self
     end
 
     private
@@ -103,13 +101,16 @@ module SendGridActionMailer
     end
 
     def perform_send_request(email)
+      # SendGrid::API is a wrapper of that...
+      # https://github.com/sendgrid/ruby-http-client/blob/master/lib/ruby_http_client.rb
+      client = SendGrid::API.new(api_key: settings.fetch(:api_key)).client
       result = client.mail._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
 
       if result.status_code && result.status_code.start_with?('4')
         message = JSON.parse(result.body).fetch('errors').pop.fetch('message')
         full_message = "Sendgrid delivery failed with #{result.status_code} #{message}"
 
-        raise_delivery_errors ? raise(SendgridDeliveryError, full_message) : warn(full_message)
+        settings[:raise_delivery_errors] ? raise(SendgridDeliveryError, full_message) : warn(full_message)
       end
 
       result

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -100,10 +100,13 @@ module SendGridActionMailer
       end
     end
 
-    def perform_send_request(email)
+    def client
       # SendGrid::API is a wrapper of that...
       # https://github.com/sendgrid/ruby-http-client/blob/master/lib/ruby_http_client.rb
-      client = SendGrid::API.new(api_key: settings.fetch(:api_key)).client
+      @client ||= SendGrid::API.new(api_key: settings.fetch(:api_key)).client
+    end
+
+    def perform_send_request(email)
       result = client.mail._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
 
       if result.status_code && result.status_code.start_with?('4')

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 module SendGridActionMailer
   describe DeliveryMethod do
     subject(:mailer) do
-      DeliveryMethod.new(api_user: 'user', api_key: 'key')
+      DeliveryMethod.new(api_key: 'key')
     end
 
     class TestClient
@@ -30,6 +30,33 @@ module SendGridActionMailer
       end
     end
 
+    describe 'settings' do
+      it 'has correct api_key' do
+        m = DeliveryMethod.new(api_key: 'ABCDEFG')
+        expect(m.settings[:api_key]).to eq('ABCDEFG')
+      end
+
+      it 'default raise_delivery_errors' do
+        m = DeliveryMethod.new()
+        expect(m.settings[:raise_delivery_errors]).to eq(false)
+      end
+
+      it 'sets raise_delivery_errors' do
+        m = DeliveryMethod.new(raise_delivery_errors: true)
+        expect(m.settings[:raise_delivery_errors]).to eq(true)
+      end
+
+      it 'default return_response' do
+        m = DeliveryMethod.new()
+        expect(mailer.settings[:return_response]).to eq(nil)
+      end
+
+      it 'sets return_response' do
+        m = DeliveryMethod.new(return_response: true)
+        expect(m.settings[:return_response]).to eq(true)
+      end
+    end
+
     describe '#deliver!' do
       let(:client) { TestClient.new }
       let(:mail) do
@@ -49,6 +76,17 @@ module SendGridActionMailer
       it 'sets to' do
         mailer.deliver!(mail)
         expect(client.sent_mail['personalizations'][0]).to eq({"to"=>[{"email"=>"test@sendgrid.com"}]})
+      end
+
+      it 'returns mailer itself' do
+        ret = mailer.deliver!(mail)
+        expect(ret).to eq(mailer)
+      end
+
+      it 'returns api response' do
+        m = DeliveryMethod.new(return_response: true, api_key: 'key')
+        ret = m.deliver!(mail)
+        expect(ret.status_code).to eq('200')
       end
 
       context 'there are ccs' do


### PR DESCRIPTION
This pull request fixes the issue #27.

- Make the settings attribute can be modified after instantiated the DeliveryMethod class
- Add :return_response option support

referred implementation: https://github.com/mikel/mail/blob/master/lib/mail/network/delivery_methods/smtp.rb