### PR TITLE
Add dynamic template data

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -33,6 +33,7 @@ module SendGridActionMailer
       add_mail_settings(sendgrid_mail, mail)
       add_tracking_settings(sendgrid_mail, mail)
 
+
       response = perform_send_request(sendgrid_mail)
 
       settings[:return_response] ? response : self
@@ -78,9 +79,14 @@ module SendGridActionMailer
         to_emails(mail.to).each { |to| p.add_to(to) }
         to_emails(mail.cc).each { |cc| p.add_cc(cc) }
         to_emails(mail.bcc).each { |bcc| p.add_bcc(bcc) }
-        p.add_substitution(Substitution.new(key: "%asm_group_unsubscribe_raw_url%", value: "<%asm_group_unsubscribe_raw_url%>"))
-        p.add_substitution(Substitution.new(key: "%asm_global_unsubscribe_raw_url%", value: "<%asm_global_unsubscribe_raw_url%>"))
-        p.add_substitution(Substitution.new(key: "%asm_preferences_raw_url%", value: "<%asm_preferences_raw_url%>"))
+
+        if mail['dynamic_template_data']
+          p.add_dynamic_template_data(json_parse(mail['dynamic_template_data'].value))
+        else
+          p.add_substitution(Substitution.new(key: "%asm_group_unsubscribe_raw_url%", value: "<%asm_group_unsubscribe_raw_url%>"))
+          p.add_substitution(Substitution.new(key: "%asm_global_unsubscribe_raw_url%", value: "<%asm_global_unsubscribe_raw_url%>"))
+          p.add_substitution(Substitution.new(key: "%asm_preferences_raw_url%", value: "<%asm_preferences_raw_url%>"))
+        end
       end
     end
 

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'mail', '~> 2.5'
-  spec.add_dependency 'sendgrid-ruby', '~> 5.0'
+  spec.add_dependency 'sendgrid-ruby', '~> 5.2.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.1.0'
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -351,6 +351,11 @@ module SendGridActionMailer
             expect(client.sent_mail['tracking_settings']).to eq(tracking)
           end
         end
+
+        # TBD if the official gem has this feature released
+        context 'dynamic template data' do
+
+        end
       end
 
       context 'multipart/alternative' do


### PR DESCRIPTION
The latest SendGrid API has new templates with a feature called ``dynamic_template_data`` added via the personalisation object. There is no official gem version yet, only on master branch.

- [ ] Wait for official gem release for the correct dependency configuration
- [ ] Implement specs if ``sendgrid-ruby`` gem has this also officially implemented
