### PR TITLE
Remove memoization of client

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -55,7 +55,7 @@ module SendGridActionMailer
     def client
       key = @api_key || settings.fetch(:api_key)
 
-      @client ||= SendGrid::API.new(api_key: key).client
+      @client = SendGrid::API.new(api_key: key).client
     end
 
     # type should be either :plain or :html


### PR DESCRIPTION
Remove memoization of SendGrid client, allowing for dynamic API keys.