### PR TITLE
Point to rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An ActionMailer adapter to send email using SendGrid's HTTPS Web API (instead of
 
 Add this line to your application's Gemfile:
 
-    gem 'sendgrid-actionmailer', github: 'eddiezane/sendgrid-actionmailer'
+    gem 'sendgrid-actionmailer'
 
 ## Usage
 


### PR DESCRIPTION
Seems like the gem is up-to-date and released to rubygems, so probably better to point folks to that than GitHub