### PR TITLE
Clarify usage of subject, body and template_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Mail functionality is extended to include additional attributes provided by 
 [Sendgrid v3 API Documentation](https://sendgrid.com/docs/API_Reference/api_v3.html)
 
 ### template_id (string)
-The id of a template that you would like to use. If you use a template that contains a subject and content (either text or html), you do not need to specify those at the personalizations nor message level.
+The id of a template that you would like to use. If you use a template that contains a subject, you do not need to specify a subject at the personalizations nor message level. However, because of the way ActionMailer works, a body is required, even if the template contains one. If all your emails use templates with a body, you can add `default body: "not used"` to the top of your mailer.
 
 ```mail(to: 'example@email.com', subject: 'email subject', body: 'email body', template_id: 'template_1')```
 


### PR DESCRIPTION
Expands the template_id description with details about using subject and body from the SendGrid template, and how to please ActionMailer.

Fixes #39.