### PR TITLE
Modify json_parse to accept null attributes

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -136,7 +136,7 @@ module SendGridActionMailer
     end
 
     def json_parse(text, symbolize=true)
-      JSON.parse(text.gsub(/:*\"*([\%a-zA-Z0-9_-]*)\"*(( *)=>\ *)/) { "\"#{$1}\":" }, symbolize_names: symbolize)
+      JSON.parse(text ? text.gsub(/:*\"*([\%a-zA-Z0-9_-]*)\"*(( *)=>\ *)/) { "\"#{$1}\":" } : '{}', symbolize_names: symbolize)
     end
 
     def add_send_options(sendgrid_mail, mail)

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -393,6 +393,12 @@ module SendGridActionMailer
             expect(client.sent_mail['personalizations'].first['dynamic_template_data']).to eq(template_data)
           end
         end
+
+        it 'sets dynamic template data and sandbox_mode' do
+          mail['mail_settings'] = '{}'
+          mailer.deliver!(mail)
+          expect(client.sent_mail['mail_settings']).to eq(nil)
+        end
       end
 
       context 'multipart/alternative' do


### PR DESCRIPTION
Mail converts an empty hash option, {}, to null, although it is valid json.  json_parse should should test text for null and use “{}” instead.