### PR TITLE
Fix/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rvm:
   - 2.3.7
   - 2.2.10
 before_install:
-  - gem install bundler
+  - gem update --system
+  - gem update --remote bundler
 gemfile:
   - gemfiles/mail_2.5.gemfile
   - gemfiles/mail_2.6.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.2.10
 before_install:
   - gem update --system
-  - gem update --remote bundler
+  - gem install bundler -v=1.6.0
 gemfile:
   - gemfiles/mail_2.5.gemfile
   - gemfiles/mail_2.6.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.4.4
   - 2.3.4
   - 2.3.7
-  - 2.2.10
 before_install:
   - gem update --system
   - gem install bundler -v=1.6.0


### PR DESCRIPTION
Something changed recently on travis, making builds fail because of conflicts between rvm, ruby and bundler version. Dropping ruby 2.1.10, update the system gems and locking to bundler to 1.6 makes specs pass.