### PR TITLE
Handle empty hash as input for mail_settings

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -136,7 +136,7 @@ module SendGridActionMailer
     end
 
     def json_parse(text, symbolize=true)
-      JSON.parse(text ? text.gsub(/:*\"*([\%a-zA-Z0-9_-]*)\"*(( *)=>\ *)/) { "\"#{$1}\":" } : '{}', symbolize_names: symbolize)
+      JSON.parse(text.empty? ? '{}' : text.gsub(/:*\"*([\%a-zA-Z0-9_-]*)\"*(( *)=>\ *)/) { "\"#{$1}\":" }, symbolize_names: symbolize)
     end
 
     def add_send_options(sendgrid_mail, mail)

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -399,6 +399,12 @@ module SendGridActionMailer
           mailer.deliver!(mail)
           expect(client.sent_mail['mail_settings']).to eq(nil)
         end
+
+        it 'sets dynamic template data and sandbox_mode' do
+          mail['mail_settings'] = {}
+          mailer.deliver!(mail)
+          expect(client.sent_mail['mail_settings']).to eq(nil)
+        end
       end
 
       context 'multipart/alternative' do


### PR DESCRIPTION
Based on the feedback and in #41 and the changes in #42, I found a working fix for handling both empty hashes (`{}`) and empty json string hashes (`'{}'`) as values for `mail_settings`.

The `text` in `json_parse` can be an empty string when a Mail object is initialized with `mail_settings: {}`. In [`add_mail_settings`](https://github.com/eddiezane/sendgrid-actionmailer/blob/eb0a1161d9826e44e3d2c334b33f7d18841d7a69/lib/sendgrid_actionmailer.rb#L182), `json_parse` is called with the argument `mail['mail_settings'].value`, which in this case will be an empty string.

Fixes #41.