### PR TITLE
Handle Message With Empty Multipart Content

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -126,8 +126,10 @@ module SendGridActionMailer
       when 'text/html'
         sendgrid_mail.add_content(to_content(:html, mail.body.decoded))
       when 'multipart/alternative', 'multipart/mixed', 'multipart/related'
-        sendgrid_mail.add_content(to_content(:plain, mail.text_part.decoded)) if mail.text_part
-        sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if mail.html_part
+        sendgrid_mail.add_content(to_content(:plain, mail.text_part.decoded)) if
+            mail.text_part and mail.text_part.body.present?
+        sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if
+            mail.html_part and mail.html_part.body.present?
 
         mail.attachments.each do |part|
           sendgrid_mail.add_attachment(to_attachment(part))


### PR DESCRIPTION
Actionmailer is happy to have an empty text or html part to a multipart
message. This makes Sendgrid unhappy. Sendgrid will return an error when
attempting to send a message where a specific part of a multipart
message is empty.

This update allows for the behavior of actionmailer to coexist with the
requirements of the Sendgrid API.

                ##
               _[]_
              [____]
          .----'  '----.
      .===|    .==.    |===.
      \   |   /####\   |   /
      /   |   \####/   |   \
      '===|    `""`    |==='
      .===|    .==.    |===.
      \   |   /::::\   |   /
      /   |   \::::/   |   \
      '===|    `""`    |==='
      .===|    .==.    |===.
      \   |   /&&&&\   |   /
      /   |   \&&&&/   |   \
      '===|    `""`    |==='
   jgs    '--.______.--'