### PR TITLE
Update Travis CI settings to test on latest Ruby and mail gem versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.5.7
   - 2.4.9
   - 2.3.8
-  - 2.3.4
 before_install:
   - gem update --system
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9
+  - 2.3.8
   - 2.3.4
-  - 2.3.7
 before_install:
   - gem update --system
   - gem install bundler

--- a/gemfiles/mail_2.5.gemfile
+++ b/gemfiles/mail_2.5.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "mail", "2.5.4"
+gem "mail", "2.5.5"
 
 gemspec :path => "../"

--- a/gemfiles/mail_2.6.gemfile
+++ b/gemfiles/mail_2.6.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "mail", "2.6.4"
+gem "mail", "2.6.6"
 
 gemspec :path => "../"

--- a/gemfiles/mail_2.7.gemfile
+++ b/gemfiles/mail_2.7.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "mail", "2.7.0"
+gem "mail", "2.7.1"
 
 gemspec :path => "../"


### PR DESCRIPTION
I want to use this gem with Ruby 2.6.5 so I updated travis settings to test on latest Ruby and mail gem versions (and CI was completed successfully.)

https://www.ruby-lang.org/en/downloads/releases/
https://github.com/mikel/mail/releases