### PR TITLE
Lazy load ActionMailer::Base

### DIFF
--- a/lib/sendgrid_actionmailer/railtie.rb
+++ b/lib/sendgrid_actionmailer/railtie.rb
@@ -1,7 +1,9 @@
 module SendGridActionMailer
   class Railtie < Rails::Railtie
-    initializer 'sendgrid_actionmailer.add_delivery_method', before: 'action_mailer.set_configs' do
-      ActionMailer::Base.add_delivery_method(:sendgrid_actionmailer, SendGridActionMailer::DeliveryMethod)
+    initializer 'sendgrid_actionmailer.add_delivery_method' do
+      ActiveSupport.on_load(:action_mailer) do
+        ActionMailer::Base.add_delivery_method(:sendgrid_actionmailer, SendGridActionMailer::DeliveryMethod)
+      end
     end
   end
 end


### PR DESCRIPTION
Gems should not load Rails frameworks that have hooks, https://guides.rubyonrails.org/engines.html#active-support-on-load-hooks