### PR TITLE
Add personalizations field

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The personalizations object supports:
 - "custom_args" - Any custom arguments you would like to include in your email.
 - "send_at" - A specific time that you would like your email to be sent.
 
-Note that if you set a to, cc, or bcc on the mail object, this will be added to each personalized email. Other fields set in the personalizations object will override any global paramters defined outside of personalizations.
+Note that if you set a to, cc, or bcc on the mail object, this will be inserted as its own personalization separate from any you specify. Other fields set in the personalizations object will override any global parameters defined outside of personalizations.
 
 Also note that substitutions will not work with dynamic templates.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,32 @@ Data to provide for feeding the new dynamic templates in Sendgrid with valueable
 
 ```mail(to: 'example@email.com', subject: 'email subject', body: 'email body',  dynamic_template_data:{ variable_1: 'foo', variable_2: 'bar'})```
 
+### personalizations (json)
+
+Allows providing a customized [personalizations](https://sendgrid.com/docs/for-developers/sending-email/personalizations/) array for the v3 Mail Send endpoint. This allows customizing how an email is sent and also allows sending multiple different emails to different recipients with a single API call.
+
+The personalizations object supports:
+
+- "to", "cc", "bcc" - The recipients of your email.
+- "subject" - The subject of your email.
+- "headers" - Any headers you would like to include in your email.
+- "substitutions" - Any substitutions you would like to be made for your email.
+- "custom_args" - Any custom arguments you would like to include in your email.
+- "send_at" - A specific time that you would like your email to be sent.
+
+Note that if you set a to, cc, or bcc on the mail object, this will be added to each personalized email. Other fields set in the personalizations object will override any global paramters defined outside of personalizations.
+
+Also note that substitutions will not work with dynamic templates.
+
+```
+mail(subject: 'default subject', 'email body', personalizations: [
+  { to: { email: 'example@example.com' }},
+  { to: { email: 'example2@example.com' }}
+])
+
+```
+
+
 ### Unsubscribe Links
 
 Sendgrid unfortunately uses <% %> for their default substitution syntax, which makes it incompatible with Rails templates. Their proposed solution is to use Personalization Substitutions with the v3 Mail Send Endpoint.  This gem makes that modification to make the following Rails friendly unsubscribe urls.

--- a/README.md
+++ b/README.md
@@ -233,10 +233,16 @@ The personalizations object supports:
 - "substitutions" - Any substitutions you would like to be made for your email.
 - "custom_args" - Any custom arguments you would like to include in your email.
 - "send_at" - A specific time that you would like your email to be sent.
+- "dynamic_template_data" - data for dynamic templates.
 
-Note that if you set a to, cc, or bcc on the mail object, this will be inserted as its own personalization separate from any you specify. Other fields set in the personalizations object will override any global parameters defined outside of personalizations.
+The following should be noted about these personalization attributes:
+- to, cc, or bcc: if either to, cc, or bcc is also set when calling mail, those addresses provided to mail will be inserted as a separate personalization from the ones you provide. However, when using personalizations, you are not required to specify `to` when calling the mail function.
+- dynamic_template_data specified in the mail function will be merged with any dynamic_template_data specified in the personalizations object (with the personalizations object keys having priority).
+- Other fields set in the personalizations object will override any global parameters defined outside of personalizations.
 
 Also note that substitutions will not work with dynamic templates.
+
+Example usage:
 
 ```
 mail(subject: 'default subject', 'email body', personalizations: [

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -33,7 +33,6 @@ module SendGridActionMailer
       add_mail_settings(sendgrid_mail, mail)
       add_tracking_settings(sendgrid_mail, mail)
 
-
       response = perform_send_request(sendgrid_mail)
 
       settings[:return_response] ? response : self
@@ -102,8 +101,14 @@ module SendGridActionMailer
         p.subject = personalization_hash['subject']
       end
 
-      if mail['dynamic_template_data']
-        p.add_dynamic_template_data(json_parse(mail['dynamic_template_data'].value))
+      if mail['dynamic_template_data'] || personalization_hash['dynamic_template_data']
+        if mail['dynamic_template_data']
+          data = json_parse(mail['dynamic_template_data'].value, false)
+          data.merge!(personalization_hash['dynamic_template_data'] || {})
+        else
+          data = personalization_hash['dynamic_template_data']
+        end
+        p.add_dynamic_template_data(data)
       elsif mail['template_id'].nil?
         p.add_substitution(Substitution.new(key: "%asm_group_unsubscribe_raw_url%", value: "<%asm_group_unsubscribe_raw_url%>"))
         p.add_substitution(Substitution.new(key: "%asm_global_unsubscribe_raw_url%", value: "<%asm_global_unsubscribe_raw_url%>"))

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -74,39 +74,33 @@ module SendGridActionMailer
       end
     end
 
-    def setup_personalization(mail, personalization_hash = nil)
+    def setup_personalization(mail, personalization_hash)
       p = Personalization.new
 
-      if personalization_hash
-        (personalization_hash['to'] || []).each do |to|
-          p.add_to Email.new(email: to['email'], name: to['name'])
-        end
-        (personalization_hash['cc'] || []).each do |cc|
-          p.add_cc Email.new(email: cc['email'], name: cc['name'])
-        end
-        (personalization_hash['bcc'] || []).each do |bcc|
-          p.add_bcc Email.new(email: bcc['email'], name: bcc['name'])
-        end
-        (personalization_hash['headers'] || []).each do |header_key, header_value|
-          p.add_header Header.new(key: header_key, value: header_value)
-        end
-        (personalization_hash['substitutions'] || {}).each do |sub_key, sub_value|
-          p.add_substitution(Substitution.new(key: sub_key, value: sub_value))
-        end
-        (personalization_hash['custom_args'] || {}).each do |arg_key, arg_value|
-          p.add_custom_arg(CustomArg.new(key: arg_key, value: arg_value))
-        end
-        if personalization_hash['send_at']
-          p.send_at = personalization_hash['send_at']
-        end
-        if personalization_hash['subject']
-          p.subject = personalization_hash['subject']
-        end
+      (personalization_hash['to'] || []).each do |to|
+        p.add_to Email.new(email: to['email'], name: to['name'])
       end
-
-      to_emails(mail.to).each { |to| p.add_to(to) }
-      to_emails(mail.cc).each { |cc| p.add_cc(cc) }
-      to_emails(mail.bcc).each { |bcc| p.add_bcc(bcc) }
+      (personalization_hash['cc'] || []).each do |cc|
+        p.add_cc Email.new(email: cc['email'], name: cc['name'])
+      end
+      (personalization_hash['bcc'] || []).each do |bcc|
+        p.add_bcc Email.new(email: bcc['email'], name: bcc['name'])
+      end
+      (personalization_hash['headers'] || []).each do |header_key, header_value|
+        p.add_header Header.new(key: header_key, value: header_value)
+      end
+      (personalization_hash['substitutions'] || {}).each do |sub_key, sub_value|
+        p.add_substitution(Substitution.new(key: sub_key, value: sub_value))
+      end
+      (personalization_hash['custom_args'] || {}).each do |arg_key, arg_value|
+        p.add_custom_arg(CustomArg.new(key: arg_key, value: arg_value))
+      end
+      if personalization_hash['send_at']
+        p.send_at = personalization_hash['send_at']
+      end
+      if personalization_hash['subject']
+        p.subject = personalization_hash['subject']
+      end
 
       if mail['dynamic_template_data']
         p.add_dynamic_template_data(json_parse(mail['dynamic_template_data'].value))
@@ -115,7 +109,6 @@ module SendGridActionMailer
         p.add_substitution(Substitution.new(key: "%asm_global_unsubscribe_raw_url%", value: "<%asm_global_unsubscribe_raw_url%>"))
         p.add_substitution(Substitution.new(key: "%asm_preferences_raw_url%", value: "<%asm_preferences_raw_url%>"))
       end
-
 
       p
     end
@@ -169,14 +162,19 @@ module SendGridActionMailer
     end
 
     def add_personalizations(sendgrid_mail, mail)
+      if (mail.to && mail.to.any?) || (mail.cc && mail.cc.any?) || (mail.bcc && mail.bcc.any?)
+        personalization = setup_personalization(mail, {})
+        to_emails(mail.to).each { |to| personalization.add_to(to) }
+        to_emails(mail.cc).each { |cc| personalization.add_cc(cc) }
+        to_emails(mail.bcc).each { |bcc| personalization.add_bcc(bcc) }
+        sendgrid_mail.add_personalization(personalization)
+      end
+
       if mail['personalizations']
         personalizations = json_parse('[' + mail['personalizations'].value + ']', false)
         personalizations.each do |p|
           sendgrid_mail.add_personalization(setup_personalization(mail, p))
         end
-      else
-        p = setup_personalization(mail)
-        sendgrid_mail.add_personalization(p)
       end
     end
 

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -24,10 +24,9 @@ module SendGridActionMailer
         m.from = to_email(mail.from)
         m.reply_to = to_email(mail.reply_to)
         m.subject = mail.subject || ""
-        # https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/personalizations.html
-        m.add_personalization(to_personalizations(mail))
       end
 
+      add_personalizations(sendgrid_mail, mail)
       add_api_key(sendgrid_mail, mail)
       add_content(sendgrid_mail, mail)
       add_send_options(sendgrid_mail, mail)
@@ -75,20 +74,50 @@ module SendGridActionMailer
       end
     end
 
-    def to_personalizations(mail)
-      Personalization.new.tap do |p|
-        to_emails(mail.to).each { |to| p.add_to(to) }
-        to_emails(mail.cc).each { |cc| p.add_cc(cc) }
-        to_emails(mail.bcc).each { |bcc| p.add_bcc(bcc) }
+    def setup_personalization(mail, personalization_hash = nil)
+      p = Personalization.new
 
-        if mail['dynamic_template_data']
-          p.add_dynamic_template_data(json_parse(mail['dynamic_template_data'].value))
-        elsif mail['template_id'].nil?
-          p.add_substitution(Substitution.new(key: "%asm_group_unsubscribe_raw_url%", value: "<%asm_group_unsubscribe_raw_url%>"))
-          p.add_substitution(Substitution.new(key: "%asm_global_unsubscribe_raw_url%", value: "<%asm_global_unsubscribe_raw_url%>"))
-          p.add_substitution(Substitution.new(key: "%asm_preferences_raw_url%", value: "<%asm_preferences_raw_url%>"))
+      if personalization_hash
+        (personalization_hash['to'] || []).each do |to|
+          p.add_to Email.new(email: to['email'], name: to['name'])
+        end
+        (personalization_hash['cc'] || []).each do |cc|
+          p.add_cc Email.new(email: cc['email'], name: cc['name'])
+        end
+        (personalization_hash['bcc'] || []).each do |bcc|
+          p.add_bcc Email.new(email: bcc['email'], name: bcc['name'])
+        end
+        (personalization_hash['headers'] || []).each do |header_key, header_value|
+          p.add_header Header.new(key: header_key, value: header_value)
+        end
+        (personalization_hash['substitutions'] || {}).each do |sub_key, sub_value|
+          p.add_substitution(Substitution.new(key: sub_key, value: sub_value))
+        end
+        (personalization_hash['custom_args'] || {}).each do |arg_key, arg_value|
+          p.add_custom_arg(CustomArg.new(key: arg_key, value: arg_value))
+        end
+        if personalization_hash['send_at']
+          p.send_at = personalization_hash['send_at']
+        end
+        if personalization_hash['subject']
+          p.subject = personalization_hash['subject']
         end
       end
+
+      to_emails(mail.to).each { |to| p.add_to(to) }
+      to_emails(mail.cc).each { |cc| p.add_cc(cc) }
+      to_emails(mail.bcc).each { |bcc| p.add_bcc(bcc) }
+
+      if mail['dynamic_template_data']
+        p.add_dynamic_template_data(json_parse(mail['dynamic_template_data'].value))
+      elsif mail['template_id'].nil?
+        p.add_substitution(Substitution.new(key: "%asm_group_unsubscribe_raw_url%", value: "<%asm_group_unsubscribe_raw_url%>"))
+        p.add_substitution(Substitution.new(key: "%asm_global_unsubscribe_raw_url%", value: "<%asm_global_unsubscribe_raw_url%>"))
+        p.add_substitution(Substitution.new(key: "%asm_preferences_raw_url%", value: "<%asm_preferences_raw_url%>"))
+      end
+
+
+      p
     end
 
     def to_attachment(part)
@@ -137,6 +166,18 @@ module SendGridActionMailer
 
     def json_parse(text, symbolize=true)
       JSON.parse(text.empty? ? '{}' : text.gsub(/:*\"*([\%a-zA-Z0-9_-]*)\"*(( *)=>\ *)/) { "\"#{$1}\":" }, symbolize_names: symbolize)
+    end
+
+    def add_personalizations(sendgrid_mail, mail)
+      if mail['personalizations']
+        personalizations = json_parse('[' + mail['personalizations'].value + ']', false)
+        personalizations.each do |p|
+          sendgrid_mail.add_personalization(setup_personalization(mail, p))
+        end
+      else
+        p = setup_personalization(mail)
+        sendgrid_mail.add_personalization(p)
+      end
     end
 
     def add_send_options(sendgrid_mail, mail)

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -593,7 +593,6 @@ module SendGridActionMailer
           mail['personalizations'] = personalizations
         end
 
-
         it 'sets the provided to address personalizations' do
           mailer.deliver!(mail)
           expect(client.sent_mail['personalizations'].length).to eq(2)
@@ -649,7 +648,6 @@ module SendGridActionMailer
             '%asm_global_unsubscribe_raw_url%' => '<%asm_global_unsubscribe_raw_url%>',
             '%asm_preferences_raw_url%' => '<%asm_preferences_raw_url%>'
           })
-          expect(client.sent_mail['personalizations'][1]['substitutions']).to include(personalizations[1]['substitutions'])
           expect(client.sent_mail['personalizations'][1]['substitutions']).to include({
             '%asm_group_unsubscribe_raw_url%' => '<%asm_group_unsubscribe_raw_url%>',
             '%asm_global_unsubscribe_raw_url%' => '<%asm_global_unsubscribe_raw_url%>',
@@ -662,7 +660,7 @@ module SendGridActionMailer
             [
               {
                 to: [
-                  {email: 'john1@example.com', name: 'John 1'}
+                  { email: 'john1@example.com', name: 'John 1'}
                 ]
               }
             ]
@@ -679,47 +677,36 @@ module SendGridActionMailer
         context 'when to is set on mail object' do
           before { mail.to = 'test@sendgrid.com' }
 
-          it 'adds that to address on all personalizations' do
+          it 'adds that to address as a separate personalization' do
             mailer.deliver!(mail)
-            expect(client.sent_mail['personalizations'].length).to eq(2)
-            expect(client.sent_mail['personalizations'][0]['to']).to match_array(
-              [{"email"=>"test@sendgrid.com"}] + personalizations[0]['to']
-            )
-            expect(client.sent_mail['personalizations'][1]['to']).to match_array(
-              [{"email"=>"test@sendgrid.com"}] + personalizations[1]['to']
-            )
+            expect(client.sent_mail['personalizations'].length).to eq(3)
+            expect(client.sent_mail['personalizations'][0]['to']).to eq([{"email"=>"test@sendgrid.com"}])
+            expect(client.sent_mail['personalizations'][1]['to']).to eq(personalizations[0]['to'])
+            expect(client.sent_mail['personalizations'][2]['to']).to eq(personalizations[1]['to'])
           end
         end
 
         context 'when cc is set on mail object' do
           before { mail.cc = 'test@sendgrid.com' }
 
-          it 'adds that cc address on all personalizations' do
+          it 'adds that cc address as a separate personalization' do
             mailer.deliver!(mail)
-            expect(client.sent_mail['personalizations'].length).to eq(2)
-            expect(client.sent_mail['personalizations'][0]['to']).to eq(personalizations[0]['to'])
-            expect(client.sent_mail['personalizations'][0]['cc']).to eq(
-              [{"email"=>"test@sendgrid.com"}]
-            )
-            expect(client.sent_mail['personalizations'][1]['cc']).to match_array(
-              [{"email"=>"test@sendgrid.com"}] + personalizations[1]['cc']
-            )
+            expect(client.sent_mail['personalizations'].length).to eq(3)
+            expect(client.sent_mail['personalizations'][0]['cc']).to eq([{"email"=>"test@sendgrid.com"}])
+            expect(client.sent_mail['personalizations'][1]['cc']).to eq(personalizations[0]['cc'])
+            expect(client.sent_mail['personalizations'][2]['cc']).to eq(personalizations[1]['cc'])
           end
         end
 
         context 'when bcc is set on mail object' do
           before { mail.bcc = 'test@sendgrid.com' }
 
-          it 'adds that bcc address on all personalizations' do
+          it 'adds that bcc address as a separate personalization' do
             mailer.deliver!(mail)
-            expect(client.sent_mail['personalizations'].length).to eq(2)
-            expect(client.sent_mail['personalizations'][0]['to']).to eq(personalizations[0]['to'])
-            expect(client.sent_mail['personalizations'][0]['bcc']).to eq(
-              [{"email"=>"test@sendgrid.com"}]
-            )
-            expect(client.sent_mail['personalizations'][1]['bcc']).to match_array(
-              [{"email"=>"test@sendgrid.com"}] + personalizations[1]['bcc']
-            )
+            expect(client.sent_mail['personalizations'].length).to eq(3)
+            expect(client.sent_mail['personalizations'][0]['bcc']).to eq([{"email"=>"test@sendgrid.com"}])
+            expect(client.sent_mail['personalizations'][1]['bcc']).to eq(personalizations[0]['bcc'])
+            expect(client.sent_mail['personalizations'][2]['bcc']).to eq(personalizations[1]['bcc'])
           end
         end
       end


### PR DESCRIPTION
Resolves my feature request https://github.com/eddiezane/sendgrid-actionmailer/issues/59

There are a couple design notes here that I was unsure about:

First, I convert the provided personalizations array of hashes into SendGrid::Personalization objects. This makes it easier to deal with combining with other information already added to a personalization (see below), and these objects also work better with sendgrid-ruby.

sendgrid-ruby calls `to_json()` on whichever object is passed into `add_personalization` (and then calls to_json again later before making the API call). However, `Personalization`'s `to_json` method converts to a ruby hash, rather than outputting a json string. If a ruby hash or array of hashes is passed into sendgrid-ruby's `add_personalization`, it will get converted into a json string twice, resulting in a failed API request. Probably sendgrid-ruby should not be calling and using `to_json` in `add_personalization` and instead call the method `to_hash`, but it seemed like this wasn't the place to deal with that.

Second, if a user specifies `to`, `cc`, or `bcc` on the mail object, I add those as an initial personalization separate from other personalizations provided.

It seemed unclear what should be done here. I don't find the combined used of `to` and `personalizations` obvious and couldn't find a clear example from other libraries. `sendgrid-nodejs` [silently drops without warning](https://github.com/sendgrid/sendgrid-nodejs/blob/master/packages/helpers/classes/mail.js#L106) the to, cc, and bcc fields if a personalizations object is provided (regardless of what is in the personalizations object). However, `sendgrid-ruby` [creates a personalization ](https://github.com/sendgrid/sendgrid-ruby/blob/master/lib/sendgrid/helpers/mail/mail.rb#L33) with the to address separate from any personalizations a user adds, which I figured is the approach we should mirror, and just document it.

Let me know what you think and if you think I should take a different approach anywhere.