### PR TITLE
Revert "Lazy load ActionMailer::Base"

### DIFF
--- a/lib/sendgrid_actionmailer/railtie.rb
+++ b/lib/sendgrid_actionmailer/railtie.rb
@@ -1,9 +1,7 @@
 module SendGridActionMailer
   class Railtie < Rails::Railtie
-    initializer 'sendgrid_actionmailer.add_delivery_method' do
-      ActiveSupport.on_load(:action_mailer) do
-        ActionMailer::Base.add_delivery_method(:sendgrid_actionmailer, SendGridActionMailer::DeliveryMethod)
-      end
+    initializer 'sendgrid_actionmailer.add_delivery_method', before: 'action_mailer.set_configs' do
+      ActionMailer::Base.add_delivery_method(:sendgrid_actionmailer, SendGridActionMailer::DeliveryMethod)
     end
   end
 end

--- a/lib/sendgrid_actionmailer/version.rb
+++ b/lib/sendgrid_actionmailer/version.rb
@@ -1,3 +1,3 @@
 module SendGridActionMailer
-  VERSION = '2.4.1'.freeze
+  VERSION = '2.4.2'.freeze
 end


### PR DESCRIPTION
Reverts eddiezane/sendgrid-actionmailer#57

This commit resulted in the following error:
gems/actionmailer-5.2.2.1/lib/action_mailer/base.rb:582:in `method_missing': undefined method `sendgrid_actionmailer_settings=' for ActionMailer::Base:Class