### PR TITLE
Dont send content types with dynamic templates

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -153,16 +153,22 @@ module SendGridActionMailer
     end
 
     def add_content(sendgrid_mail, mail)
-      case mail.mime_type
-      when 'text/plain'
-        sendgrid_mail.add_content(to_content(:plain, mail.body.decoded))
-      when 'text/html'
-        sendgrid_mail.add_content(to_content(:html, mail.body.decoded))
-      when 'multipart/alternative', 'multipart/mixed', 'multipart/related'
-        sendgrid_mail.add_content(to_content(:plain, mail.text_part.decoded)) if mail.text_part
-        sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if mail.html_part
-
+      if mail['template_id']
+        # We are sending a template, so we don't need to add any content outside
+        # of attachments
         add_attachments(sendgrid_mail, mail)
+      else
+        case mail.mime_type
+        when 'text/plain'
+          sendgrid_mail.add_content(to_content(:plain, mail.body.decoded))
+        when 'text/html'
+          sendgrid_mail.add_content(to_content(:html, mail.body.decoded))
+        when 'multipart/alternative', 'multipart/mixed', 'multipart/related'
+          sendgrid_mail.add_content(to_content(:plain, mail.text_part.decoded)) if mail.text_part
+          sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if mail.html_part
+
+          add_attachments(sendgrid_mail, mail)
+        end
       end
     end
 

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -146,6 +146,12 @@ module SendGridActionMailer
       end
     end
 
+    def add_attachments(sendgrid_mail, mail)
+      mail.attachments.each do |part|
+        sendgrid_mail.add_attachment(to_attachment(part))
+      end
+    end
+
     def add_content(sendgrid_mail, mail)
       case mail.mime_type
       when 'text/plain'
@@ -156,9 +162,7 @@ module SendGridActionMailer
         sendgrid_mail.add_content(to_content(:plain, mail.text_part.decoded)) if mail.text_part
         sendgrid_mail.add_content(to_content(:html, mail.html_part.decoded)) if mail.html_part
 
-        mail.attachments.each do |part|
-          sendgrid_mail.add_attachment(to_attachment(part))
-        end
+        add_attachments(sendgrid_mail, mail)
       end
     end
 

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -269,6 +269,15 @@ module SendGridActionMailer
           mailer.deliver!(mail)
           expect(client.sent_mail['content']).to eq(nil)
         end
+
+        it 'does not set send a content type even if body is given' do
+          # This matches the default behavior of ActionMail. body must be
+          # specified and content_type defaults to text/plain.
+          mail.body = 'I heard you like pineapple.'
+          mail.content_type = 'text/plain'
+          mailer.deliver!(mail)
+          expect(client.sent_mail['content']).to eq(nil)
+        end
       end
 
       context 'without dynamic template data or a template id' do

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -264,6 +264,11 @@ module SendGridActionMailer
           mailer.deliver!(mail)
           expect(client.sent_mail['personalizations'].first).to_not have_key('substitutions')
         end
+
+        it 'does not set send a content type' do
+          mailer.deliver!(mail)
+          expect(client.sent_mail['content']).to eq(nil)
+        end
       end
 
       context 'without dynamic template data or a template id' do


### PR DESCRIPTION
By default ActionMailer::Base#mail requires `body` to be specified and it defaults `content_type` to `text/plain`. Using those defaults we'd end up only delivering `text/plain` parts to the recipient even if the dynamic template includes both HTML and Text.

* Sending content.type keys to SendGrid when using Dynamic Templates means
SendGrid will only generate and send those parts of the template.
* Sending no content.type keys means SendGrid will generate both text/plain and
text/html versions of the template and deliver those.

This change allows users to keep asking for specific content type, ie if they
only want to send a HTML version for some reason:

    mail(
      :body => "Unused",
      :content_type => "text/html",
      :to => "someone@example.com"
    )

This closes #68 