### PR TITLE
Fix personalizations example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,9 @@ Example usage:
 
 ```
 mail(subject: 'default subject', 'email body', personalizations: [
-  { to: { email: 'example@example.com' }},
-  { to: { email: 'example2@example.com' }}
+  { to: [{ email: 'example@example.com' }]},
+  { to: [{ email: 'example2@example.com' }]}
 ])
-
 ```
 
 


### PR DESCRIPTION
I was running into some trouble getting personalizations to trigger. After digging around, I found [this code](https://github.com/eddiezane/sendgrid-actionmailer/blob/master/lib/sendgrid_actionmailer.rb#L82) where it looks like `personalizations_hash['to']` is expecting an array, not a hash as in the README.

This PR just updates the docs to better reflect the underlying logic. Let me know if I missed something!