### PR TITLE
feature/settings_perform_send_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 3.0.2 - 2020-4-20
+
+### Changes
+
+- perform_send_request setting for testing perposes
+
 ## 3.0.1 - 2020-4-3
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ mail(subject: 'default subject', 'email body', personalizations: [
 
 ```
 
-
 ### Unsubscribe Links
 
 Sendgrid unfortunately uses <% %> for their default substitution syntax, which makes it incompatible with Rails templates. Their proposed solution is to use Personalization Substitutions with the v3 Mail Send Endpoint. This gem makes that modification to make the following Rails friendly unsubscribe urls.
@@ -264,3 +263,9 @@ Sendgrid unfortunately uses <% %> for their default substitution syntax, which m
  * `<a href="%asm_preferences_raw_url%">Manage Email Preferences</a>`
 
 Note: This feature, and substitutions in general, do not work in combination with dynamic templates.
+
+## Testing
+
+The setting `perform_send_request` is available to disable sending for testing purposes. Setting perform_send_request false and return_response true enables the testing of the JSON API payload.
+
+

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -229,7 +229,7 @@ module SendGridActionMailer
         asm =  asm.delete_if { |key, value| 
           !key.to_s.match(/(group_id)|(groups_to_display)/) }
         if asm.keys.map(&:to_s).include?('group_id')
-          sendgrid_mail.asm = ASM.new(asm)
+          sendgrid_mail.asm = ASM.new(self.class.transform_keys(asm, &:to_sym))
         end
       end
       if mail['ip_pool_name']

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -34,7 +34,11 @@ module SendGridActionMailer
       add_mail_settings(sendgrid_mail, mail)
       add_tracking_settings(sendgrid_mail, mail)
 
-      response = perform_send_request(sendgrid_mail)
+      if (settings[:perform_send_request] == false)
+        response = sendgrid_mail
+      else
+        response = perform_send_request(sendgrid_mail)
+      end
 
       settings[:return_response] ? response : self
     end

--- a/lib/sendgrid_actionmailer/version.rb
+++ b/lib/sendgrid_actionmailer/version.rb
@@ -1,3 +1,3 @@
 module SendGridActionMailer
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -59,6 +59,11 @@ module SendGridActionMailer
         m = DeliveryMethod.new(return_response: true)
         expect(m.settings[:return_response]).to eq(true)
       end
+
+      it 'sets perform_deliveries' do
+        m = DeliveryMethod.new(perform_send_request: false)
+        expect(m.settings[:perform_send_request]).to eq(false)
+      end
     end
 
     describe '#deliver!' do
@@ -754,6 +759,14 @@ module SendGridActionMailer
             expect(client.sent_mail['personalizations'][0]['bcc']).to eq(personalizations[0]['bcc'])
             expect(client.sent_mail['personalizations'][1]['bcc']).to eq(personalizations[1]['bcc'])
             expect(client.sent_mail['personalizations'][2]['bcc']).to eq([{"email"=>"test@sendgrid.com"}])
+          end
+        end
+
+        context 'when perform_send_request false' do
+          it 'should not send and email and return json body' do
+            m = DeliveryMethod.new(perform_send_request: false, return_response: true, api_key: 'key')
+            response = m.deliver!(mail)
+            expect(response).to respond_to(:to_json)
           end
         end
       end


### PR DESCRIPTION
The ability to disable api requests for testing purposes. When used in combination with return_response = true, it allows the testing of the mail object as it would be sent to sendgrid through the send grid ruby gem. Attempts to address #77
