### PR TITLE
Fix Content-ID values to fix inline attachments

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -135,7 +135,7 @@ module SendGridActionMailer
         a.disposition = disposition unless disposition.nil?
 
         has_content_id = part.header && part.has_content_id?
-        a.content_id = part.header['content_id'].value if has_content_id
+        a.content_id = part.header['content_id'].field.content_id if has_content_id
       end
     end
 

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -554,6 +554,9 @@ module SendGridActionMailer
           expect(content['filename']).to eq('specs.rb')
           expect(content['type']).to eq('application/x-ruby')
           expect(content['content_id'].class).to eq(String)
+          expect(content['content_id']).to include("@")
+          expect(content['content_id']).not_to include("<")
+          expect(content['content_id']).not_to include(">")
         end
       end
 


### PR DESCRIPTION
The previous `Content-ID` values were being passed to the `content_id` part of the SendGrid API in the format of `<cid>` (with brackets). While this is the correct format of the `Content-ID` header, the SendGrid API does not expect the extra brackets in the values passed to the `content_id` field in the API. Instead, the API just expects the inner `cid` value only, since it appends the brackets itself.

When brackets are passed along to the API, then it leads to values like this in the e-mails sent from SendGrid:

```
Content-ID: <<cid>>
```

Due to the double brackets in the value, inline attachments couldn't successfully reference the expected cid values.

This fixes these issues by setting the `content_id` value to just the `cid` value, which SendGrid will then wrap in brackets, so the resulting messages sent from SendGrid are in the correct format:

```
Content-ID: <cid>
```

We noticed this regression when upgrading from sendgrid-actionmailer v0.2.1 where you can see that content IDs were set using this same `field.content_id` approach to fetch the raw, un-bracketed value: https://github.com/eddiezane/sendgrid-actionmailer/blob/v0.2.1/lib/sendgrid_actionmailer.rb#L120
