### PR TITLE
globally configured mail_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Normal ActionMailer usage will now transparently be sent using SendGrid's Web AP
 
 ```mail(to: 'example@email.com', subject: 'email subject', body: 'email body')```
 
+### Mail Settings
+
+Mail settings, such as sandbox_mode, may be applied globally through the sendgrid_actionmailer_settings configuration.
+
+```ruby
+config.action_mailer.delivery_method = :sendgrid_actionmailer
+config.action_mailer.sendgrid_actionmailer_settings = {
+  api_key: ENV['SENDGRID_API_KEY'],
+  mail_settings: { sandbox_mode: { enable: true }}
+}
+```
+
 ### Dynamic API Key
 
 If you need to send mail for a number of Sendgrid accounts, you can set the API key for these as follows:

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -27,10 +27,6 @@ module SendGridActionMailer
         m.subject = mail.subject || ""
       end
 
-      if self.settings[:mail_settings]
-        sendgrid_mail.mail_settings = self.settings[:mail_settings]
-      end
-
       add_personalizations(sendgrid_mail, mail)
       add_api_key(sendgrid_mail, mail)
       add_content(sendgrid_mail, mail)
@@ -242,8 +238,10 @@ module SendGridActionMailer
     end
 
     def add_mail_settings(sendgrid_mail, mail)
-      if mail['mail_settings']
-        settings = mail['mail_settings'].unparsed_value || {}
+      local_settings = mail['mail_settings'] && mail['mail_settings'].unparsed_value || {}
+      global_settings = self.settings[:mail_settings] || {}
+      settings = global_settings.merge(local_settings)
+      unless settings.empty?
         sendgrid_mail.mail_settings = MailSettings.new.tap do |m|
           if settings[:bcc]
             m.bcc = BccSettings.new(**settings[:bcc])

--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -27,6 +27,10 @@ module SendGridActionMailer
         m.subject = mail.subject || ""
       end
 
+      if self.settings[:mail_settings]
+        sendgrid_mail.mail_settings = self.settings[:mail_settings]
+      end
+
       add_personalizations(sendgrid_mail, mail)
       add_api_key(sendgrid_mail, mail)
       add_content(sendgrid_mail, mail)

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -772,6 +772,14 @@ module SendGridActionMailer
             expect(response).to respond_to(:to_json)
           end
         end
+
+        context 'when mail_settings are present' do
+          it 'should apply mail_settings to request body' do
+            m = DeliveryMethod.new(api_key: 'key', return_response: true,  mail_settings: { sandbox_mode: {enable: true }})
+            m.deliver!(mail)
+            expect(client.sent_mail['mail_settings']).to eq({ sandbox_mode: {enable: true }}.to_json)
+          end
+        end
       end
     end
   end

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -777,7 +777,38 @@ module SendGridActionMailer
           it 'should apply mail_settings to request body' do
             m = DeliveryMethod.new(api_key: 'key', return_response: true,  mail_settings: { sandbox_mode: {enable: true }})
             m.deliver!(mail)
-            expect(client.sent_mail['mail_settings']).to eq({ sandbox_mode: {enable: true }}.to_json)
+            expect(client.sent_mail['mail_settings']).to eq("sandbox_mode" => {"enable" => true })
+          end
+
+          context 'when mail has mail_settings set' do
+            before { mail['mail_settings'] = { spam_check: { enable: true } } }
+
+            it 'should combine local mail_settings with global settings' do
+              m = DeliveryMethod.new(api_key: 'key', return_response: true,  mail_settings: { sandbox_mode: {enable: true }})
+              m.deliver!(mail)
+              expect(client.sent_mail['mail_settings']).to eq(
+                "sandbox_mode" => {"enable" => true },
+                "spam_check" => {"enable" => true },
+              )
+            end
+          end
+
+          context 'when mail contains the same setting as global settings' do
+            before do
+              mail['mail_settings'] = {
+                sandbox_mode: { enable: false },
+                spam_check: { enable: true }
+              }
+            end
+
+            it 'should apply local mail_settings on top of global settings' do
+              m = DeliveryMethod.new(api_key: 'key', return_response: true,  mail_settings: { sandbox_mode: {enable: true }})
+              m.deliver!(mail)
+              expect(client.sent_mail['mail_settings']).to eq(
+                "sandbox_mode" => {"enable" => false },
+                "spam_check" => {"enable" => true },
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
This feature allows mail_settings, such as sandbox_mode, to be applied globally through the sendgrid_actionmailer_settings configuration.