### PR TITLE
Railtie should use ActiveSupport.on_load

### DIFF
--- a/lib/sendgrid_actionmailer/railtie.rb
+++ b/lib/sendgrid_actionmailer/railtie.rb
@@ -1,7 +1,9 @@
 module SendGridActionMailer
   class Railtie < Rails::Railtie
     initializer 'sendgrid_actionmailer.add_delivery_method', before: 'action_mailer.set_configs' do
-      ActionMailer::Base.add_delivery_method(:sendgrid_actionmailer, SendGridActionMailer::DeliveryMethod)
+      ActiveSupport.on_load(:action_mailer) do
+        ActionMailer::Base.add_delivery_method(:sendgrid_actionmailer, SendGridActionMailer::DeliveryMethod)
+      end
     end
   end
 end


### PR DESCRIPTION
The current initializer is forcing all the onload hooks to be fired which causes config options set in config/initializers to be ignored. 
