### PR TITLE
Add http_options to configurable in mailer settings

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -46,7 +46,7 @@ module SendGridActionMailer
     private
 
     def client
-      @client = SendGrid::API.new(api_key: api_key).client
+      @client = SendGrid::API.new(api_key: api_key, http_options: settings.fetch(:http_options, {})).client
     end
 
     # type should be either :plain or :html

--- a/sendgrid-actionmailer.gemspec
+++ b/sendgrid-actionmailer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'mail', '~> 2.7'
-  spec.add_dependency 'sendgrid-ruby', '~> 6.0'
+  spec.add_dependency 'sendgrid-ruby', '~> 6.4'
 
   spec.add_development_dependency 'appraisal', '~> 2.1.0'
   spec.add_development_dependency 'bundler'

--- a/spec/lib/sendgrid_actionmailer_spec.rb
+++ b/spec/lib/sendgrid_actionmailer_spec.rb
@@ -64,6 +64,11 @@ module SendGridActionMailer
         m = DeliveryMethod.new(perform_send_request: false)
         expect(m.settings[:perform_send_request]).to eq(false)
       end
+
+      it 'sets http_options' do
+        m = DeliveryMethod.new(http_options: {open_timeout: 40})
+        expect(m.settings[:http_options]).to eq({open_timeout: 40})
+      end
     end
 
     describe '#deliver!' do
@@ -106,11 +111,11 @@ module SendGridActionMailer
         end
 
         it 'sets dynamic api_key, but should revert to default settings api_key' do
-          expect(SendGrid::API).to receive(:new).with(api_key: 'key')
+          expect(SendGrid::API).to receive(:new).with(api_key: 'key', http_options: {})
           mailer.deliver!(default)
-          expect(SendGrid::API).to receive(:new).with(api_key: 'test_key')
+          expect(SendGrid::API).to receive(:new).with(api_key: 'test_key', http_options: {})
           mailer.deliver!(mail)
-          expect(SendGrid::API).to receive(:new).with(api_key: 'key')
+          expect(SendGrid::API).to receive(:new).with(api_key: 'key', http_options: {})
           mailer.deliver!(default)
         end
       end


### PR DESCRIPTION
Fixes #97 

### What

- Make http_options to be configurable in settings
- Add test for http_options

### Why
- As I mention here https://github.com/eddiezane/sendgrid-actionmailer/issues/97#issuecomment-746709842 . I had added the http_options as constructor params in this PR https://github.com/sendgrid/sendgrid-ruby/pull/455 of `sendgrid-ruby`. So, I hope the http_options available in your gem too.