### PR TITLE
The SendGrid API has a habit of sending back an error message as JSON…

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -284,9 +284,7 @@ module SendGridActionMailer
       result = client.mail._('send').post(request_body: email.to_json) # ლ(ಠ益ಠლ) that API
 
       if result.status_code && result.status_code.start_with?('4')
-        message = !(result.body.empty?) ? JSON.parse(result.body).fetch('errors').pop.fetch('message') : 'Sendgrid API Error'
-        full_message = "Sendgrid delivery failed with #{result.status_code} #{message}"
-
+        full_message = "Sendgrid delivery failed with #{result.status_code}: #{result.body}"
         settings[:raise_delivery_errors] ? raise(SendgridDeliveryError, full_message) : warn(full_message)
       end
 


### PR DESCRIPTION
…, or a string, or a null response. Let’s simplify this and just return whatever SendGrid responds with.