### PR TITLE
Allow local settings to be set to the settings object. Previously set…

### DIFF
--- a/lib/sendgrid_actionmailer.rb
+++ b/lib/sendgrid_actionmailer.rb
@@ -233,7 +233,7 @@ module SendGridActionMailer
       end
       if mail['asm']
         asm = mail['asm'].unparsed_value
-        asm =  asm.delete_if { |key, value| 
+        asm = asm.delete_if { |key, value|
           !key.to_s.match(/(group_id)|(groups_to_display)/) }
         if asm.keys.map(&:to_s).include?('group_id')
           sendgrid_mail.asm = ASM.new(**self.class.transform_keys(asm, &:to_sym))
@@ -248,6 +248,8 @@ module SendGridActionMailer
       local_settings = mail['mail_settings'] && mail['mail_settings'].unparsed_value || {}
       global_settings = self.settings[:mail_settings] || {}
       settings = global_settings.merge(local_settings)
+      self.settings.merge!(**self.class.transform_keys(settings, &:to_sym))
+
       unless settings.empty?
         sendgrid_mail.mail_settings = MailSettings.new.tap do |m|
           if settings[:bcc]

--- a/lib/sendgrid_actionmailer/version.rb
+++ b/lib/sendgrid_actionmailer/version.rb
@@ -1,3 +1,3 @@
 module SendGridActionMailer
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.2.1'.freeze
 end


### PR DESCRIPTION
Allow local settings to be set to the settings object. Previously setting perform_send_request would only work if added to the initial settings, but want to allow setting on subsequent calls to mail()

